### PR TITLE
Change .get() return value to entire http response body

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,6 +1,6 @@
 AllCops:
     Exclude:
-        - lib/prometheus/api_client/version.rb
+        - lib/prometheus/alert_buffer_client/version.rb
 
 AlignHash:
     EnforcedHashRocketStyle: table
@@ -22,6 +22,7 @@ Metrics/BlockLength:
         - 'spec/**/*.rb'
 
 Metrics/LineLength:
+    Max: 120
     Exclude:
         - 'spec/**/*.rb'
 

--- a/Gemfile
+++ b/Gemfile
@@ -7,6 +7,7 @@ def ruby_version?(constraint)
 end
 
 gem 'faraday'
+gem 'faraday_middleware'
 
 group :test do
   gem 'coveralls'

--- a/README.md
+++ b/README.md
@@ -37,6 +37,10 @@ alerts = prometheus.get()
 
 alerts = prometheus.get(generation_id: '12497ca8-b597-4590-ac5d-d55af7f3d185', from_index: 34)
 
+Alerts will be returned in a Hash with following keys:
+* generationID
+* messages
+
 #### Posting alerts
 \# post an alert JSON to server
 

--- a/examples/get_alerts.rb
+++ b/examples/get_alerts.rb
@@ -4,4 +4,6 @@ require 'prometheus/alert_buffer_client'
 prometheus = Prometheus::AlertBufferClient::Client.new(url: 'http://localhost:9099', path: '/topics/test')
 
 alerts = prometheus.get(generation_id: '12497ca8-b597-4590-ac5d-d55af7f3d185', from_index: 1)
-puts alerts
+
+puts "Generation Id: #{alerts['generationID']}"
+puts "Alerts: #{alerts['messages']}"

--- a/examples/post_alerts.rb
+++ b/examples/post_alerts.rb
@@ -5,4 +5,3 @@ prometheus = Prometheus::AlertBufferClient::Client.new(url: 'http://localhost:90
 
 prometheus.post '{"posted":"alert"}'
 prometheus.post '{"alertId":12}'
-

--- a/lib/prometheus/alert_buffer_client.rb
+++ b/lib/prometheus/alert_buffer_client.rb
@@ -5,13 +5,10 @@ require 'openssl'
 require 'prometheus/alert_buffer_client/client'
 
 module Prometheus
-
   # Alert Client is a ruby implementation for a Prometheus-alert-buffer client.
   module AlertBufferClient
-
     def self.client(options = {})
       Client.new(options)
     end
-
   end
 end

--- a/lib/prometheus/alert_buffer_client/client.rb
+++ b/lib/prometheus/alert_buffer_client/client.rb
@@ -21,7 +21,6 @@ module Prometheus
         },
       }.freeze
 
-
       # Create a Prometheus Alert client:
       #
       # @param [Hash] options
@@ -40,12 +39,11 @@ module Prometheus
 
         @client = Faraday.new(
           faraday_options(options),
-        )  do |conn|
+        ) do |conn|
           conn.response(:json)
           conn.adapter(Faraday.default_adapter)
         end
       end
-
 
       # Get alerts:
       #
@@ -101,7 +99,7 @@ module Prometheus
         return unless headers && headers[:token]
 
         {
-          Authorization: "Bearer #{headers[:token].to_s}",
+          Authorization: "Bearer #{headers[:token]}",
         }
       end
 
@@ -128,7 +126,6 @@ module Prometheus
           request: faraday_request(options),
         }
       end
-
     end
   end
 end

--- a/lib/prometheus/alert_buffer_client/client.rb
+++ b/lib/prometheus/alert_buffer_client/client.rb
@@ -49,6 +49,7 @@ module Prometheus
       # @option options [String] :generation_id Database generation Id.
       # @option options [Integer] :from_index Minimal index of alerts to fetch.
       #
+      # @return [Hash] response with keys: generationID, messages
       # All alerts will be fetched if options are omitted.
       def get(options = {})
         response = @client.get do |req|
@@ -56,7 +57,9 @@ module Prometheus
           req.params['fromIndex'] = options[:from_index]
         end
 
-        JSON.parse(response.body)['messages']
+        JSON.parse(response.body)
+      rescue
+        raise RequestError, 'Bad response from server'
       end
 
       # post alert:

--- a/lib/prometheus/alert_buffer_client/client.rb
+++ b/lib/prometheus/alert_buffer_client/client.rb
@@ -62,8 +62,6 @@ module Prometheus
         end
 
         response.body
-      rescue 
-        raise RequestError, 'Bad response from server'
       end
 
       # post alert:
@@ -72,8 +70,6 @@ module Prometheus
         @client.post do |req|
           req.body = alert
         end
-      rescue
-        raise RequestError, 'Bad response from server'
       end
 
       # Helper function to evalueate the low level proxy option

--- a/lib/prometheus/alert_buffer_client/client.rb
+++ b/lib/prometheus/alert_buffer_client/client.rb
@@ -2,6 +2,7 @@
 
 require 'json'
 require 'faraday'
+require 'faraday_middleware'
 
 module Prometheus
   # Alert Client is a ruby implementation for a Prometheus-alert-buffer client.
@@ -39,7 +40,10 @@ module Prometheus
 
         @client = Faraday.new(
           faraday_options(options),
-        )
+        )  do |conn|
+          conn.response(:json)
+          conn.adapter(Faraday.default_adapter)
+        end
       end
 
 
@@ -57,8 +61,8 @@ module Prometheus
           req.params['fromIndex'] = options[:from_index]
         end
 
-        JSON.parse(response.body)
-      rescue
+        response.body
+      rescue 
         raise RequestError, 'Bad response from server'
       end
 

--- a/lib/prometheus/alert_buffer_client/version.rb
+++ b/lib/prometheus/alert_buffer_client/version.rb
@@ -2,6 +2,6 @@
 
 module Prometheus
   module AlertBufferClient
-    VERSION = '0.1.0'
+    VERSION = '0.2.0'
   end
 end


### PR DESCRIPTION
Extend get return value to a hash that also includes 'generationID', in addition to previously returned 'messages'

Also change prometheus to return json parsed response and propagate exceptions to external application