### PR TITLE
Allow updated (>0.9.2) faraday versions

### DIFF
--- a/prometheus-alert-buffer-client.gemspec
+++ b/prometheus-alert-buffer-client.gemspec
@@ -15,5 +15,5 @@ Gem::Specification.new do |s|
   s.files             = %w(README.md) + Dir.glob('{lib/**/*}')
   s.require_paths     = ['lib']
 
-  s.add_dependency 'faraday', '~> 0.9.2'
+  s.add_dependency 'faraday', '>= 0.9.2', '< 2.0.0'
 end


### PR DESCRIPTION
[Faraday got updated](https://github.com/lostisland/faraday/pull/1101) and [we over at manageiq](https://github.com/ManageIQ/manageiq/issues/19760) were hoping maybe that you all might be amenable to updating so we can support ruby 2.7.

Thanks!